### PR TITLE
Redux Thunk Version Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ yarn-error.log*
 .vscode
 
 #config
-firebase-config.js
+#firebase-config.js

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "redux-devtools-extension": "^2.13.2",
     "redux-first-router": "0.0.16-next",
     "redux-first-router-link": "^1.4.2",
-    "redux-thunk": "^2.2.0",
+    "redux-thunk": "~2.2.0",
     "simple-peer": "^9.0.0",
     "three": "~0.86.0",
     "uuid": "^3.2.1"

--- a/src/firebase-config.js
+++ b/src/firebase-config.js
@@ -1,0 +1,12 @@
+/*jshint esversion: 6 */
+
+var fbConfig = {
+    apiKey: "AIzaSyDy-Yo_zDWl2SU7o1RqviKpaAUlURDWh2U",
+    authDomain: "gtove2.firebaseapp.com",
+    databaseURL: "https://gtove2.firebaseio.com",
+    projectId: "gtove2",
+    storageBucket: "gtove2.appspot.com",
+    messagingSenderId: "828285745103"
+};
+
+export default fbConfig;


### PR DESCRIPTION
As it relates to: https://plus.google.com/108851116367563588787/posts/4aginGWWb5W

Redux thunk issue: https://github.com/reduxjs/redux-thunk/issues/203

For expediency I've added a fb config file here.  I've set redux thunk to `~2.2.0` as suggested.  

Fails to compile with error:

`(390,50): Property 'multiple' does not exist on type 'IntrinsicAttributes & Pick<never, never> & Partial<{ type: string; }> & { children?: ReactNode; }'.`

Error with redux-thunk set to ^2.20  (2.3.0):

`TS2315: Type 'Middleware' is not generic.`